### PR TITLE
Sniffing html

### DIFF
--- a/lib/w3cjs.js
+++ b/lib/w3cjs.js
@@ -102,9 +102,12 @@ var parseCssValidation = function(resultHtml){
 
     require('xml2js').parseString(resultHtml, function(err, result){
 
-        var results = result.html.body[0]
-            .div[1].div[0].div[0].div[0]
-            .table[0].tr;
+        var results = [];
+        try {
+            var results = result.html.body[0]
+                .div[1].div[0].div[0].div[0]
+                .table[0].tr;
+        }catch(err){}
 
         for (var i = 0; i < results.length; i++) {
             var line = trim(results[i].td[0]._);


### PR DESCRIPTION
When the validator returns no error's there is no html table inside the html. Fixed the sniffing part of the result html from W3C.
